### PR TITLE
QUILLT-386 Adds npm packages: compression, method-override, morgan, serve-favicon

### DIFF
--- a/nodePackages/basic-auth/2.0.0.nix
+++ b/nodePackages/basic-auth/2.0.0.nix
@@ -1,0 +1,22 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "basic-auth";
+    version = "2.0.0";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz";
+      sha1 = "015db3f353e02e56377755f962742e8981e7bbba";
+    };
+    deps = with nodePackages; [
+      safe-buffer_5-1-1
+    ];
+    meta = {
+      homepage = "https://github.com/jshttp/basic-auth#readme";
+      description = "node.js basic auth parser";
+      keywords = [
+        "basic"
+        "auth"
+        "authorization"
+        "basicauth"
+      ];
+    };
+  }

--- a/nodePackages/compressible/2.0.14.nix
+++ b/nodePackages/compressible/2.0.14.nix
@@ -1,0 +1,22 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "compressible";
+    version = "2.0.14";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz";
+      sha1 = "326c5f507fbb055f54116782b969a81b67a29da7";
+    };
+    deps = with nodePackages; [
+      mime-db_1-35-0
+    ];
+    meta = {
+      homepage = "https://github.com/jshttp/compressible#readme";
+      description = "Compressible Content-Type / mime checking";
+      keywords = [
+        "compress"
+        "gzip"
+        "mime"
+        "content-type"
+      ];
+    };
+  }

--- a/nodePackages/compression/1.7.3.nix
+++ b/nodePackages/compression/1.7.3.nix
@@ -1,0 +1,22 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "compression";
+    version = "1.7.3";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz";
+      sha1 = "27e0e176aaf260f7f2c2813c3e440adb9f1993db";
+    };
+    deps = with nodePackages; [
+      vary_1-1-2
+      on-headers_1-0-1
+      debug_2-6-9
+      accepts_1-3-5
+      compressible_2-0-14
+      safe-buffer_5-1-2
+      bytes_3-0-0
+    ];
+    meta = {
+      homepage = "https://github.com/expressjs/compression#readme";
+      description = "Node.js compression middleware";
+    };
+  }

--- a/nodePackages/default.nix
+++ b/nodePackages/default.nix
@@ -571,7 +571,8 @@
     base64id = callPackage ./base64id/1.0.0.nix {};
     base64id_1-0-0 = callPackage ./base64id/1.0.0.nix {};
     base64id_0-1-0 = callPackage ./base64id/0.1.0.nix {};
-    basic-auth = callPackage ./basic-auth/1.0.3.nix {};
+    basic-auth = callPackage ./basic-auth/2.0.0.nix {};
+    basic-auth_2-0-0 = callPackage ./basic-auth/2.0.0.nix {};
     basic-auth_1-0-3 = callPackage ./basic-auth/1.0.3.nix {};
     basic-auth-connect = callPackage ./basic-auth-connect/1.0.0.nix {};
     basic-auth-connect_1-0-0 = callPackage ./basic-auth-connect/1.0.0.nix {};
@@ -1118,9 +1119,11 @@
     compress-commons = callPackage ./compress-commons/1.1.0.nix {};
     compress-commons_1-1-0 = callPackage ./compress-commons/1.1.0.nix {};
     compress-commons_0-2-9 = callPackage ./compress-commons/0.2.9.nix {};
-    compressible = callPackage ./compressible/2.0.6.nix {};
+    compressible = callPackage ./compressible/2.0.14.nix {};
+    compressible_2-0-14 = callPackage ./compressible/2.0.14.nix {};
     compressible_2-0-6 = callPackage ./compressible/2.0.6.nix {};
-    compression = callPackage ./compression/1.6.0.nix {};
+    compression = callPackage ./compression/1.7.3.nix {};
+    compression_1-7-3 = callPackage ./compression/1.7.3.nix {};
     compression_1-6-0 = callPackage ./compression/1.6.0.nix {};
     compression_1-5-2 = callPackage ./compression/1.5.2.nix {};
     compression_1-3-1 = callPackage ./compression/1.3.1.nix {};
@@ -3865,7 +3868,8 @@
     merge-stream = callPackage ./merge-stream/1.0.0.nix {};
     merge-stream_1-0-0 = callPackage ./merge-stream/1.0.0.nix {};
     merge-stream_0-1-8 = callPackage ./merge-stream/0.1.8.nix {};
-    method-override = callPackage ./method-override/2.3.5.nix {};
+    method-override = callPackage ./method-override/3.0.0.nix {};
+    method-override_3-0-0 = callPackage ./method-override/3.0.0.nix {};
     method-override_2-3-5 = callPackage ./method-override/2.3.5.nix {};
     methods = callPackage ./methods/1.1.2.nix {};
     methods_1-1-2 = callPackage ./methods/1.1.2.nix {};
@@ -3997,7 +4001,8 @@
     mongojs_0-14-2 = callPackage ./mongojs/0.14.2.nix {};
     mongoose = callPackage ./mongoose/4.2.7.nix {};
     mongoose_4-2-7 = callPackage ./mongoose/4.2.7.nix {};
-    morgan = callPackage ./morgan/1.6.1.nix {};
+    morgan = callPackage ./morgan/1.9.0.nix {};
+    morgan_1-9-0 = callPackage ./morgan/1.9.0.nix {};
     morgan_1-6-1 = callPackage ./morgan/1.6.1.nix {};
     mothership = callPackage ./mothership/0.2.0.nix {};
     mothership_0-2-0 = callPackage ./mothership/0.2.0.nix {};
@@ -4010,7 +4015,8 @@
     mpromise_0-5-4 = callPackage ./mpromise/0.5.4.nix {};
     mquery = callPackage ./mquery/1.6.3.nix {};
     mquery_1-6-3 = callPackage ./mquery/1.6.3.nix {};
-    ms = callPackage ./ms/2.0.0.nix {};
+    ms = callPackage ./ms/2.1.1.nix {};
+    ms_2-1-1 = callPackage ./ms/2.1.1.nix {};
     ms_2-0-0 = callPackage ./ms/2.0.0.nix {};
     ms_0-7-2 = callPackage ./ms/0.7.2.nix {};
     ms_0-7-1 = callPackage ./ms/0.7.1.nix {};
@@ -5441,7 +5447,8 @@
     sentence-case_1-1-3 = callPackage ./sentence-case/1.1.3.nix {};
     sequencify = callPackage ./sequencify/0.0.7.nix {};
     sequencify_0-0-7 = callPackage ./sequencify/0.0.7.nix {};
-    serve-favicon = callPackage ./serve-favicon/2.3.0.nix {};
+    serve-favicon = callPackage ./serve-favicon/2.5.0.nix {};
+    serve-favicon_2-5-0 = callPackage ./serve-favicon/2.5.0.nix {};
     serve-favicon_2-3-0 = callPackage ./serve-favicon/2.3.0.nix {};
     serve-index = callPackage ./serve-index/1.7.2.nix {};
     serve-index_1-7-2 = callPackage ./serve-index/1.7.2.nix {};

--- a/nodePackages/method-override/3.0.0.nix
+++ b/nodePackages/method-override/3.0.0.nix
@@ -1,0 +1,19 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "method-override";
+    version = "3.0.0";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz";
+      sha1 = "6ab0d5d574e3208f15b0c9cf45ab52000468d7a2";
+    };
+    deps = with nodePackages; [
+      vary_1-1-2
+      debug_3-1-0
+      methods_1-1-2
+      parseurl_1-3-2
+    ];
+    meta = {
+      homepage = "https://github.com/expressjs/method-override#readme";
+      description = "Override HTTP verbs";
+    };
+  }

--- a/nodePackages/morgan/1.9.0.nix
+++ b/nodePackages/morgan/1.9.0.nix
@@ -1,0 +1,26 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "morgan";
+    version = "1.9.0";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz";
+      sha1 = "d01fa6c65859b76fcf31b3cb53a3821a311d8051";
+    };
+    deps = with nodePackages; [
+      depd_1-1-2
+      on-finished_2-3-0
+      basic-auth_2-0-0
+      on-headers_1-0-1
+      debug_2-6-9
+    ];
+    meta = {
+      homepage = "https://github.com/expressjs/morgan#readme";
+      description = "HTTP request logger middleware for node.js";
+      keywords = [
+        "express"
+        "http"
+        "logger"
+        "middleware"
+      ];
+    };
+  }

--- a/nodePackages/ms/2.1.1.nix
+++ b/nodePackages/ms/2.1.1.nix
@@ -1,0 +1,14 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "ms";
+    version = "2.1.1";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz";
+      sha1 = "30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a";
+    };
+    deps = [];
+    meta = {
+      homepage = "https://github.com/zeit/ms#readme";
+      description = "Tiny millisecond conversion utility";
+    };
+  }

--- a/nodePackages/serve-favicon/2.5.0.nix
+++ b/nodePackages/serve-favicon/2.5.0.nix
@@ -1,0 +1,25 @@
+{ buildNodePackage, nodePackages, pkgs }:
+buildNodePackage {
+    name = "serve-favicon";
+    version = "2.5.0";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz";
+      sha1 = "935d240cdfe0f5805307fdfe967d88942a2cbcf0";
+    };
+    deps = with nodePackages; [
+      etag_1-8-1
+      safe-buffer_5-1-1
+      ms_2-1-1
+      parseurl_1-3-2
+      fresh_0-5-2
+    ];
+    meta = {
+      homepage = "https://github.com/expressjs/serve-favicon#readme";
+      description = "favicon serving middleware with caching";
+      keywords = [
+        "express"
+        "favicon"
+        "middleware"
+      ];
+    };
+  }


### PR DESCRIPTION
@ns-gbernsleone 

In support of https://github.com/NarrativeScience/quill2/pull/337